### PR TITLE
Update tensorflow-gpu

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,4 @@ dependencies:
     - imageio==2.1.2
     - pip:
         - moviepy
-        - tensorflow-gpu==1.4
+        - tensorflow-gpu==1.8


### PR DESCRIPTION
Update to 1.8.0 version to align with most recent zoo models, otherwise, students will encounter problems with inference graphs.